### PR TITLE
feat: added mlflow server

### DIFF
--- a/deploy/charts/ray/templates/operator_cluster_scoped.yaml
+++ b/deploy/charts/ray/templates/operator_cluster_scoped.yaml
@@ -63,4 +63,73 @@ spec:
           limits:
             memory: 2Gi
             cpu: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monitoring
+  namespace: {{ .Values.operatorNamespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: mlflow
+      operation: monitoring
+  template:
+    metadata:
+      labels:
+        component: mlflow
+        operation: monitoring
+    spec:
+      serviceAccountName: ray-operator-serviceaccount
+      containers:
+      - name: mlflow-server
+        imagePullPolicy: IfNotPresent
+        image: guidebooks/mlflow
+        env:
+        - name: MLFLOW_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            cpu: 1
+            memory: 2Gi
+            #ephemeral-storage: 1Gi
+          limits:
+            memory: 4Gi
+            cpu: 2
+        ports:
+          - name: http
+            containerPort: 9080
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+        volumeMounts:
+        - mountPath: /mnt/mlflow-disk
+          name: mlflow-disk
+      volumes:
+      - name: mlflow-disk
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitoring-service
+  namespace: {{ .Values.operatorNamespace }}
+spec:
+  selector:
+    component: mlflow
+    operation: monitoring
+  ports:
+  - name: mlflow
+    protocol: TCP
+    port: 9080
+    targetPort: http
 {{- end }}

--- a/deploy/charts/ray/templates/operator_namespaced.yaml
+++ b/deploy/charts/ray/templates/operator_namespaced.yaml
@@ -64,4 +64,71 @@ spec:
           limits:
             memory: 2Gi
             cpu: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: mlflow
+      operation: monitoring
+  template:
+    metadata:
+      labels:
+        component: mlflow
+        operation: monitoring
+    spec:
+      serviceAccountName: ray-operator-serviceaccount
+      containers:
+      - name: mlflow-server
+        imagePullPolicy: IfNotPresent
+        image: guidebooks/mlflow
+        env:
+        - name: MLFLOW_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            cpu: 1
+            memory: 2Gi
+            #ephemeral-storage: 1Gi
+          limits:
+            memory: 4Gi
+            cpu: 2
+        ports:
+          - name: http
+            containerPort: 9080
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+        volumeMounts:
+        - mountPath: /mnt/mlflow-disk
+          name: mlflow-disk
+      volumes:
+      - name: mlflow-disk
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitoring-service
+spec:
+  selector:
+    component: mlflow
+    operation: monitoring
+  ports:
+  - name: mlflow
+    protocol: TCP
+    port: 9080
+    targetPort: http
 {{- end }}


### PR DESCRIPTION
added mlflow server to the existing helm charts

following assumptions have been made:
1. the helm chart in addition to deploying a ray cluster also deploys monitoring infrastructure
2. creates mlflow server and runs it on 9080 port
3. creates a service to expose the port over custerIP
4. no docker build for mlflow existed. had to manually create an image and push it out. 


possible additions
1. use persistent storage and/or database for mlflow
5. use s3 artificatory for storing models
6. templatize the chart more
7. add tensorboard to the list as well



here is the content of the dockerfile to build the mlflow server

```
FROM python:3.8.2-slim

RUN pip install mlflow[extras]

CMD mlflow server \
    --backend-store-uri /mnt/mlflow-disk \
    #--default-artifact-root s3://my-mlflow-bucket/ \
    --host 0.0.0.0 --port=9080
```

```
docker build -t mlflow  .                                                                                                                                 
docker push guidebooks/mlflow                                                                                                                             
```